### PR TITLE
bugfix. pass the pointer to the destroyandrecreate client as a reference

### DIFF
--- a/src/drivers/actuators/vertiq_io/vertiq_configuration_handler.hpp
+++ b/src/drivers/actuators/vertiq_io/vertiq_configuration_handler.hpp
@@ -116,13 +116,15 @@ public:
 	 * @brief Delete and recreate a client with a new object ID
 	 *
 	 * @tparam client_type The actual type of Client you want to delete and remake
-	 * @param client A pointer to the client being deleted
-	 * @param object_id The object we're making the new client with
+	 * @param client A pointer ref to the client being deleted
+	 * @param object_id The object id we're making the new client with
 	 */
 	template <typename client_type>
-	void DestroyAndRecreateClient(client_type * client, uint8_t object_id){
-		delete client;
-		client = new client_type(object_id);
+	inline void DestroyAndRecreateClient(client_type*& client, uint8_t object_id) {
+		if (client) {
+			delete client;
+			client = new client_type(object_id);
+		}
 	}
 
 	/**

--- a/src/drivers/actuators/vertiq_io/vertiq_configuration_handler.hpp
+++ b/src/drivers/actuators/vertiq_io/vertiq_configuration_handler.hpp
@@ -120,7 +120,8 @@ public:
 	 * @param object_id The object id we're making the new client with
 	 */
 	template <typename client_type>
-	inline void DestroyAndRecreateClient(client_type*& client, uint8_t object_id) {
+	void DestroyAndRecreateClient(client_type*& client, uint8_t object_id)
+	{
 		if (client) {
 			delete client;
 			client = new client_type(object_id);
@@ -134,7 +135,8 @@ public:
 	* @param entry A pointer to a Vertiq client entry
 	*/
 	template <typename iquart_data_type , typename px4_data_type>
-	void AddNewClientEntry(param_t px4_param, ClientEntryAbstract *entry){
+	void AddNewClientEntry(param_t px4_param, ClientEntryAbstract *entry)
+	{
 		if(_added_configuration_entry_wrappers < MAX_CLIENT_ENTRIES){
 			_configuration_entry_wrappers[_added_configuration_entry_wrappers] = new EntryWrapper<iquart_data_type, px4_data_type>;
 			_configuration_entry_wrappers[_added_configuration_entry_wrappers]->ConfigureStruct(px4_param, entry);


### PR DESCRIPTION
Luca found a bug with this when you turn on pulsing. I believe that didn't find the issue because when I had pulsing tested and working, I hadn't yet transitioned the deleting/recreating of the clients to a function, and was just deleting/making new manually. Since the IFCI config was working, I must have assumed the pulsing would too. That's my only guess anyway...

Regardless, Luca found that when you use the pulsing config, that changing the target module ID causes PX4 to crash. We determined that it was because of the DestroyAndRecreateClient function. Figured out the fix was to pass in the client pointer as a reference, not just the pointer. That way we're always acting on the correct item, not a local reference to it. The basic IQUART config/IFCI config must have been silently failing elsewhere without pulsing being on. Anyway, this PR fixes it.

Luca and I have both confirmed that the crash no longer happens on two different flight controllers.